### PR TITLE
Parse new format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: $(PROG) $(OUT_DIR)/groups/a.html $(OUT_DIR)/noad.sample1.html $(OUT_DIR)/no
 $(PROG): *.go cache/* extracter/*/* finder/* parser/* go.mod customize.css myapp.js
 	go build
 
-$(CACHE): cache/* extracter/*/* finder/*
+$(CACHE): $(PROG) cache/* extracter/*/* finder/*
 	 $(PROG) dump
 	mkdir -p $(OUT_DIR)
 

--- a/extracter/extract.go
+++ b/extracter/extract.go
@@ -19,57 +19,61 @@ func check(err error) {
 
 // Logic is borrowed from here: https://gist.github.com/josephg/5e134adf70760ee7e49d?permalink_comment_id=4554558#gistcomment-4554558
 func parseBinaryFile(filePath string) [][]byte {
-	var chunks [][]byte
+	var entries [][]byte
 	r, err := os.Open(filePath)
 	check(err)
+	defer r.Close()
+
 	_, err = r.Seek(0x40, io.SeekStart)
 	check(err)
 
-	// read the entire binary size
+	// read the limit marker
 	var limitMarker = make([]byte, 4, 4)
 	_, err = r.Read(limitMarker)
 	check(err)
-	var limitP = (*int32)(unsafe.Pointer(&limitMarker[0]))
+	var limit = *(*int32)(unsafe.Pointer(&limitMarker[0]))
+	entireSize := int64(limit) + 0x40
 
 	_, err = r.Seek(0x60, io.SeekStart)
 	check(err)
+
 	var entryId int
 	var blockIdx int
 	for {
-		pos, err := r.Seek(0, io.SeekCurrent)
+		filePos, err := r.Seek(0, io.SeekCurrent)
 		check(err)
-		if pos >= int64(*limitP)+0x40 {
-			return chunks
+		if filePos >= entireSize {
+			// End of File
+			return entries
 		}
 		blockIdx++
-		var blockSizeBin = make([]byte, 4, 4)
-		_, err = r.Read(blockSizeBin)
+		var blockSizeMarker = make([]byte, 4)
+		_, err = r.Read(blockSizeMarker)
 		if err == io.EOF {
 			fmt.Printf("reached EOF\n")
-			return chunks
+			return entries
 		}
-		var sz *int32 = (*int32)(unsafe.Pointer(&blockSizeBin[0]))
-		if *sz == 0 {
+		var blockSize int32 = *(*int32)(unsafe.Pointer(&blockSizeMarker[0]))
+		if blockSize == 0 {
 			panic("block size is zero")
 		}
 
-		var body = make([]byte, *sz)
-		_, err = r.Read(body)
+		var block = make([]byte, blockSize)
+		_, err = r.Read(block)
 		check(err)
 
-		btsr := bytes.NewReader(body[8:])
-		r, err := zlib.NewReader(btsr)
+		r, err := zlib.NewReader(bytes.NewReader(block[8:]))
 		check(err)
-		buf, err := io.ReadAll(r)
+		blockContents, err := io.ReadAll(r)
 		check(err)
 		chunkPos := 0
-		for chunkPos < len(buf) {
+		for chunkPos < len(blockContents) {
 			entryId++
-			var chunkSizeP *int32 = (*int32)(unsafe.Pointer(&buf[chunkPos]))
+			chunkSize := *(*int32)(unsafe.Pointer(&blockContents[chunkPos]))
 			chunkPos += 4
-			entry := buf[chunkPos : chunkPos+int(*chunkSizeP)]
-			chunks = append(chunks, entry)
-			chunkPos += int(*chunkSizeP)
+			entry := blockContents[chunkPos : chunkPos+int(chunkSize)]
+			entries = append(entries, entry)
+			chunkPos += int(chunkSize)
 		}
 		r.Close()
 	}

--- a/extracter/extract.go
+++ b/extracter/extract.go
@@ -118,8 +118,6 @@ func parseEntry(entry []byte) *raw.Entry {
 	}
 }
 
-var LastTitle = "°"
-
 func ParseBinaryFile(filePath string) []*raw.Entry {
 	var entries []*raw.Entry
 	rawEntries := parseBinaryFile(filePath)

--- a/extracter/extract.go
+++ b/extracter/extract.go
@@ -3,9 +3,11 @@ package extracter
 import (
 	"bytes"
 	"compress/zlib"
+	"fmt"
 	"github.com/DQNEO/apple-dictionary-parser/extracter/raw"
 	"io"
 	"os"
+	"unsafe"
 )
 
 func check(err error) {
@@ -14,40 +16,67 @@ func check(err error) {
 	}
 }
 
+// Logic is borrowed from here: https://gist.github.com/josephg/5e134adf70760ee7e49d?permalink_comment_id=4554558#gistcomment-4554558
 func parseBinaryFile(filePath string) [][]byte {
 	var chunks [][]byte
 
 	data, err := os.ReadFile(filePath)
 	check(err)
 	br := bytes.NewReader(data)
-	_, err = br.Seek(108, io.SeekCurrent) // skip non-zlib data in the head of the file
+	_, err = br.Seek(0x40, io.SeekStart)
 	check(err)
+	fmt.Printf("initial 0x40 bytes skipped\n")
+	// read the entire binary size
+	var limitMarker = make([]byte, 4, 4)
+	_, err = br.Read(limitMarker)
+	check(err)
+	var limitP = (*int32)(unsafe.Pointer(&limitMarker[0]))
+	fmt.Printf("limit = %d\n", *limitP)
+
+	_, err = br.Seek(0x60, io.SeekStart)
+	check(err)
+	var entryId int
+	var blockIdx int
 	for {
-		var header = make([]byte, 2)
-		_, err = br.Read(header)
-		if err == io.EOF {
-			return chunks
-		}
+		pos, err := br.Seek(0, io.SeekCurrent)
 		check(err)
-		if header[0] == 0x78 && header[1] == 0xda { // check if it's a zlib magic header
-			br.UnreadByte()
-			br.UnreadByte()
-			r, err := zlib.NewReader(br)
-			check(err)
-			buf, err := io.ReadAll(r)
-			check(err)
-			chunks = append(chunks, buf)
-			check(err)
-			r.Close()
-			_, err = br.Seek(12, io.SeekCurrent) // skip magic 12 bytes
-			if err == io.EOF {
-				// This does not happen in the current version of NOAD file
-				panic("Unexpected EOF")
-			}
-			check(err)
-		} else {
+		if pos >= int64(*limitP)+0x40 {
+			fmt.Printf("=====  read all blocks\n")
 			return chunks
 		}
+		blockIdx++
+		fmt.Printf("=====  blockIdx %d, position %d\n", blockIdx, pos)
+		var blockSizeBin = make([]byte, 4, 4)
+		_, err = br.Read(blockSizeBin)
+		if err == io.EOF {
+			fmt.Printf("reached EOF\n")
+			return chunks
+		}
+		var sz *int32 = (*int32)(unsafe.Pointer(&blockSizeBin[0]))
+		if *sz == 0 {
+			panic("block size is zero")
+		}
+		fmt.Printf("  block size = %d\n", *sz)
+		var body = make([]byte, *sz)
+		_, err = br.Read(body)
+		check(err)
+
+		btsr := bytes.NewReader(body[8:])
+		r, err := zlib.NewReader(btsr)
+		check(err)
+		buf, err := io.ReadAll(r)
+		check(err)
+		chunkPos := 0
+		for chunkPos < len(buf) {
+			entryId++
+			var chunkSize *int32 = (*int32)(unsafe.Pointer(&buf[chunkPos]))
+			chunkPos += 4
+			fmt.Printf("[entryId]: chunkSize = [%d]:%d\n", entryId, *chunkSize)
+			entry := buf[chunkPos : chunkPos+int(*chunkSize)]
+			chunks = append(chunks, entry)
+			chunkPos += int(*chunkSize)
+		}
+		r.Close()
 	}
 }
 

--- a/extracter/extract.go
+++ b/extracter/extract.go
@@ -20,10 +20,9 @@ func check(err error) {
 // Logic is borrowed from here: https://gist.github.com/josephg/5e134adf70760ee7e49d?permalink_comment_id=4554558#gistcomment-4554558
 func parseBinaryFile(filePath string) [][]byte {
 	var entries [][]byte
-	r, err := os.Open(filePath)
+	data, err := os.ReadFile(filePath)
 	check(err)
-	defer r.Close()
-
+	r := bytes.NewReader(data)
 	_, err = r.Seek(0x40, io.SeekStart)
 	check(err)
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func doDump(cCtx *cli.Context) error {
 		if bodyFilePath == "" {
 			panic("File not bodyFilePath")
 		}
-		fmt.Printf("Dictionary file is bodyFilePath at '%s'\n", bodyFilePath)
+		fmt.Printf("Dictionary file is found at '%s'\n", bodyFilePath)
 		dictFilePath = bodyFilePath
 	} else {
 		dictFilePath = flagDictFilePath


### PR DESCRIPTION
To solve https://github.com/DQNEO/apple-dictionary-parser/issues/2

Seemingly MacOS's dicionary file format was changed. 
This pull request changes our parsing logic accordingly.

I've confirmed this works for  MacOS Sonoma Version 14.6.1 (23G93)